### PR TITLE
Add allowed_teams attribute to `block` step

### DIFF
--- a/lib/buildkite/pipelines/steps/block.rb
+++ b/lib/buildkite/pipelines/steps/block.rb
@@ -16,6 +16,7 @@ module Buildkite
         attribute :branches
         attribute :fields
         attribute :blocked_state
+        attribute :allowed_teams
       end
     end
   end


### PR DESCRIPTION
Buildkite [recently introduced](https://buildkite.com/resources/changelog/298-granular-block-step-permissions-using-allowedteams/) the ability to allow only certain teams to unblock block steps.

https://buildkite.com/docs/pipelines/configure/step-types/block-step#permissions